### PR TITLE
Fixes motor object exit.

### DIFF
--- a/control_scheme/Motor.py
+++ b/control_scheme/Motor.py
@@ -44,7 +44,7 @@ class Motor:
 
         print("FSESC Connected")
 
-    def __del__(self):
+    def exit(self):
         self.active = False
         pass
 


### PR DESCRIPTION
Motor Object destroyer method removed and replaced with a exit() method.