### PR TITLE
Replaced Current with Duty Cycle

### DIFF
--- a/control_scheme/Motor.py
+++ b/control_scheme/Motor.py
@@ -36,6 +36,7 @@ class Motor:
 
 
         self.duty_cycle = 0
+        self.neutral = 5000
 
         self.active = True
         self.delta = 1
@@ -57,7 +58,8 @@ class Motor:
             if self.current_time != self.previous_time:
 
                 try:
-                    self.FSESC.write(self.duty_cycle_packet(self.duty_cycle))
+                    print("Duty Cycle", self.duty_cycle)
+                    self.FSESC.write(Motor.duty_cycle_packet(self.duty_cycle))
                     self.FSESC.flush()
                 except:
                     raise Exception("COULD NOT WRITE TO FSESC")
@@ -67,6 +69,15 @@ class Motor:
 
     def set_duty_cycle(self, value):
         self.duty_cycle = value
+
+    def handle_duty_cycle(self, value):
+
+        applied_Neutral = round(self.neutral*(value / abs(value)))
+        calculated_Duty_Cycle = value + applied_Neutral
+        print(calculated_Duty_Cycle)
+        self.set_duty_cycle(calculated_Duty_Cycle)
+
+
 
     @staticmethod
     def duty_cycle_packet(value) -> bytes:

--- a/control_scheme/Motor.py
+++ b/control_scheme/Motor.py
@@ -34,7 +34,8 @@ class Motor:
         except:
             raise Exception('COULD NOT CONNECT TO FSESC')
 
-        self.current = 0
+
+        self.duty_cycle = 0
 
         self.active = True
         self.delta = 1
@@ -46,7 +47,7 @@ class Motor:
 
     def exit(self):
         self.active = False
-        pass
+
 
     @threaded
     def run(self):
@@ -54,21 +55,22 @@ class Motor:
 
             self.current_time = time.time()
             if self.current_time != self.previous_time:
-                print("Current: ", self.current)
+
                 try:
-                    self.FSESC.write(self.current_packet(self.current))
+                    self.FSESC.write(self.duty_cycle_packet(self.duty_cycle))
                     self.FSESC.flush()
                 except:
                     raise Exception("COULD NOT WRITE TO FSESC")
                 self.previous_time = time.time()
 
-    def set_current(self, value):
-        self.current = value
-        pass
+
+
+    def set_duty_cycle(self, value):
+        self.duty_cycle = value
 
     @staticmethod
-    def current_packet(value) -> bytes:
+    def duty_cycle_packet(value) -> bytes:
 
-        message = pyvesc.SetCurrent(value)
+        message = pyvesc.SetDutyCycle(value)
         packet = pyvesc.encode(message)
         return packet

--- a/test_cases/control_test_mac.py
+++ b/test_cases/control_test_mac.py
@@ -12,50 +12,30 @@ import time
 def main():
 
 
-    servo_port_string = select_port()
-    servo_port = serial.Serial(servo_port_string, 9600, timeout=0.1)
+    # servo_port_string = select_port()
+    # servo_port = serial.Serial(servo_port_string, 9600, timeout=0.1)
 
-    # motor_port_string = select_port()
-    # motor_port = serial.Serial(motor_port_string, 11500, timeout=0.1)
+    motor_port_string = select_port()
+    motor_port = serial.Serial(motor_port_string, 11500, timeout=0.1)
 
-    # motor = Motor(port)
-    servo = Servo(servo_port)
+    motor = Motor(motor_port)
+    #servo = Servo(servo_port)
 
-    Servo.build_packet('T',5)
-    # motor.run()
-
-
-    # motor.set_current(2900)
-    servo.set_steering(100)
+    #Servo.build_packet('T',5)
+    motor.run()
 
 
+    motor.handle_duty_cycle(3000)
+    #servo.set_steering(100)
 
-    x = 65
-    while x<135:
-        x += 2
-        servo.set_steering(x)
-        time.sleep(0.1)
-        print("Angle Read Directly: ", servo.read_angle())
-    while x>65:
-        x -= 2
-        servo.set_steering(x)
-        time.sleep(0.1)
-        print("Angle Read Directly: ", servo.read_angle())
-    while x < 135:
-        x += 2
-        servo.set_steering(x)
-        time.sleep(0.1)
-        print("Angle Read Directly: ", servo.read_angle())
-    while x > 65:
-        x -= 2
-        servo.set_steering(x)
-        time.sleep(0.1)
-        print("Angle Read Directly: ", servo.read_angle())
 
-    # time.sleep(5)
 
-    # del motor
-    del servo
+
+    time.sleep(10)
+    motor.exit()
+
+
+
 
     return
 


### PR DESCRIPTION
Added a handle_Duty_Cycle() method to Motor which takes neutral (tested at 5000 and -5000) and adds or subtracts your value to the neutral so the user doesn't have to jump across the neutral gap.

ex:
Maps

|Input | Actual |
|------|-------|
| 1    | 5001  |
| 200 | 5200  |
| -1   | -5001 |
| -200 | -5200 |

Replaced current_packet() method with duty_cycle_packet() method
Replaced set_current() method with set_duty_cycle() method

Changed appropriate values in run loop

Edited testCasesMac file for testing.